### PR TITLE
Add unix timestamp support

### DIFF
--- a/scrimbot.py
+++ b/scrimbot.py
@@ -29,8 +29,17 @@ async def add(ctx, scrimTime):
         return
 
     if scrimTime in timeList:
+        # generate fancy timestamp
+        time = dt.datetime.now()
+        if int(scrimTime.split(":")[0]) < time.hour:
+            day = time.day
+        else:
+            day = time.day+1
+        scrimDate = dt.datetime(time.year, time.month, day, int(scrimTime.split(":")[0]),
+                                int(scrimTime.split(":")[1]), 0, 0)
+        unix = int(scrimDate.timestamp())
         # Send the message and reactions.
-        message = await ctx.send("New scrim at " + scrimTime + ".")
+        message = await ctx.send("New scrim at " + scrimTime + "<t:" + str(unix)+":R>" + ".")
         await message.add_reaction("👍")
         await message.add_reaction("🇷")
         await message.add_reaction("⏭️")


### PR DESCRIPTION
Should add support for discord's new timestamping to the bot's initial scrim message
e.g. New scrim at 20:00 in 15 minutes.
(clicking this message gives local time too. When more people will definitely be able to see this could even replace the main time indicator)